### PR TITLE
Adds section on installing f2 on macOS using brew

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -113,6 +113,14 @@ chmod +x f2
 sudo mv f2 /usr/local/bin
 ```
 
+### Brew
+
+Alternatively, F2 can also be installed using brew:
+
+```sh
+brew install f2
+```
+
 ## Install on Windows
 
 ### Binary Downloads


### PR DESCRIPTION
I tried installing f2 using brew, even though I knew there was no mention of it in the documentation. When I saw that it actually works, I thought it would be good to add it to the documentation. 

Cheers!